### PR TITLE
[infra] 빌드 아티팩트 모듈별 디렉토리 분리 + parsing-api Playwright 런타임 배포 포함

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -19,6 +19,7 @@ env:
   AWS_REGION: ap-northeast-2
   AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME_DEV }}
   BUILD_DIR_NAME: wishboard-v2-build-dev
+  PHASE: dev
 
 jobs:
   changes:
@@ -28,7 +29,7 @@ jobs:
       parsing_api: ${{ steps.filter.outputs.parsing_api || steps.fallback.outputs.parsing_api }}
       push: ${{ steps.filter.outputs.push        || steps.fallback.outputs.push }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - id: filter
         if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
@@ -66,7 +67,7 @@ jobs:
         working-directory: api
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Create Spring secret files
         run: |
@@ -75,7 +76,7 @@ jobs:
           echo "${{ secrets.APPLICATION_DEV_YML }}" > src/main/resources/application-dev.yml
 
       - name: Set up JDK 21 (Corretto)
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
           java-version: '21'
@@ -88,13 +89,13 @@ jobs:
 
       - name: Package artefacts
         run: |
-          mkdir -p api
-          cp -r build/libs/* api/
-          cp ../v2-pm2-run-dev.js api/
-          cp ../deploy.sh api/
+          mkdir -p ../artifact/api
+          cp build/libs/* ../artifact/api/
+          cp ../v2-pm2-run-${{ env.PHASE }}.js ../artifact/
+          cp ../deploy.sh ../artifact/
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_S3_ACCESS_KEY_DEV }}
           aws-secret-access-key: ${{ secrets.AWS_S3_SECRET_KEY_DEV }}
@@ -102,7 +103,7 @@ jobs:
 
       - name: Upload to S3
         run: |
-          aws s3 cp --recursive ./api s3://$AWS_S3_BUCKET_NAME/$BUILD_DIR_NAME
+          aws s3 cp --recursive ../artifact s3://$AWS_S3_BUCKET_NAME/$BUILD_DIR_NAME
 
   # ---------------------------------------------------------------------------
   # parsing-api (Node 22.x LTS, .nvmrc single source of truth)
@@ -130,11 +131,8 @@ jobs:
       - name: Verify npm version
         run: npm -v
 
-      - name: npm ci (clean install)
+      - name: npm ci (clean install, dev 포함)
         run: npm ci
-
-      #      - name: ESLint check
-      #        run: npm run lint
 
       - name: Create .env
         run: |
@@ -145,13 +143,20 @@ jobs:
       - name: Build (dev)
         run: npm run build --if-present
 
-      - name: Copy deploy artifacts
-        run: |
-          cp ../v2-pm2-run-dev.js ./dist/
-          cp ../deploy.sh ./dist/
+      - name: Prune dev dependencies (playwright 만 잔존)
+        run: npm prune --omit=dev
 
-      - name: Rename build directory
-        run: mv dist parsing-api
+      - name: Package artefacts
+        run: |
+          mkdir -p ../artifact/parsing-api
+          # webpack 빌드 산출물
+          cp -r dist/. ../artifact/parsing-api/
+          # webpack externals 로 분리된 playwright 런타임을 함께 배포
+          cp -r node_modules ../artifact/parsing-api/
+          cp package.json package-lock.json ../artifact/parsing-api/
+          # 공통 파일
+          cp ../v2-pm2-run-${{ env.PHASE }}.js ../artifact/
+          cp ../deploy.sh ../artifact/
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -160,9 +165,9 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_S3_SECRET_KEY_DEV }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Upload dist to S3
+      - name: Upload artefacts to S3
         run: |
-          aws s3 cp --recursive ./parsing-api s3://$AWS_S3_BUCKET_NAME/$BUILD_DIR_NAME
+          aws s3 cp --recursive ../artifact s3://$AWS_S3_BUCKET_NAME/$BUILD_DIR_NAME
 
   # ---------------------------------------------------------------------------
   # push (Node 22.x LTS)
@@ -193,9 +198,6 @@ jobs:
       - name: npm ci (clean install)
         run: npm ci
 
-      #      - name: ESLint check
-      #        run: npm run lint
-
       - name: Create .env
         run: |
           touch .env
@@ -208,13 +210,14 @@ jobs:
       - name: Build (dev)
         run: npm run build --if-present
 
-      - name: Copy deploy artifacts
+      - name: Package artefacts
         run: |
-          cp ../v2-pm2-run-dev.js ./dist/
-          cp ../deploy.sh ./dist/
-
-      - name: Rename build directory
-        run: mv dist push
+          mkdir -p ../artifact/push
+          # webpack 번들에 모든 의존성 inline (native 의존 없음 → node_modules 불필요)
+          cp -r dist/. ../artifact/push/
+          # 공통 파일
+          cp ../v2-pm2-run-${{ env.PHASE }}.js ../artifact/
+          cp ../deploy.sh ../artifact/
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -223,6 +226,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_S3_SECRET_KEY_DEV }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Upload dist to S3
+      - name: Upload artefacts to S3
         run: |
-          aws s3 cp --recursive ./push s3://$AWS_S3_BUCKET_NAME/$BUILD_DIR_NAME
+          aws s3 cp --recursive ../artifact s3://$AWS_S3_BUCKET_NAME/$BUILD_DIR_NAME

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -19,6 +19,7 @@ env:
   AWS_REGION: ap-northeast-2
   AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME_PROD }}
   BUILD_DIR_NAME: wishboard-v2-build-prod
+  PHASE: prod
 
 jobs:
   changes:
@@ -28,7 +29,7 @@ jobs:
       parsing_api: ${{ steps.filter.outputs.parsing_api || steps.fallback.outputs.parsing_api }}
       push: ${{ steps.filter.outputs.push        || steps.fallback.outputs.push }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - id: filter
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -66,7 +67,7 @@ jobs:
         working-directory: api
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Create Spring secret files
         run: |
@@ -75,7 +76,7 @@ jobs:
           echo "${{ secrets.APPLICATION_PROD_YML }}" > src/main/resources/application-prod.yml
 
       - name: Set up JDK 21 (Corretto)
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
           java-version: '21'
@@ -88,13 +89,13 @@ jobs:
 
       - name: Package artefacts
         run: |
-          mkdir -p api
-          cp -r build/libs/* api/
-          cp ../v2-pm2-run-dev.js api/
-          cp ../deploy.sh api/
+          mkdir -p ../artifact/api
+          cp build/libs/* ../artifact/api/
+          cp ../v2-pm2-run-${{ env.PHASE }}.js ../artifact/
+          cp ../deploy.sh ../artifact/
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_S3_ACCESS_KEY_DEV }}
           aws-secret-access-key: ${{ secrets.AWS_S3_SECRET_KEY_DEV }}
@@ -102,7 +103,7 @@ jobs:
 
       - name: Upload to S3
         run: |
-          aws s3 cp --recursive ./api s3://$AWS_S3_BUCKET_NAME/$BUILD_DIR_NAME
+          aws s3 cp --recursive ../artifact s3://$AWS_S3_BUCKET_NAME/$BUILD_DIR_NAME
 
   # ---------------------------------------------------------------------------
   # parsing-api (Node 22.x LTS, .nvmrc single source of truth)
@@ -130,11 +131,8 @@ jobs:
       - name: Verify npm version
         run: npm -v
 
-      - name: npm ci (clean install)
+      - name: npm ci (clean install, dev 포함)
         run: npm ci
-
-      #      - name: ESLint check
-      #        run: npm run lint
 
       - name: Create .env
         run: |
@@ -143,15 +141,22 @@ jobs:
           echo "${{ secrets.PARSING_API_ENV }}" > .env
 
       - name: Build (prod)
-        run: npm run build --if-present
+        run: npm run build:production --if-present
 
-      - name: Copy deploy artifacts
+      - name: Prune dev dependencies (playwright 만 잔존)
+        run: npm prune --omit=dev
+
+      - name: Package artefacts
         run: |
-          cp ../v2-pm2-run-dev.js ./dist/
-          cp ../deploy.sh ./dist/
-
-      - name: Rename build directory
-        run: mv dist parsing-api
+          mkdir -p ../artifact/parsing-api
+          # webpack 빌드 산출물
+          cp -r dist/. ../artifact/parsing-api/
+          # webpack externals 로 분리된 playwright 런타임을 함께 배포
+          cp -r node_modules ../artifact/parsing-api/
+          cp package.json package-lock.json ../artifact/parsing-api/
+          # 공통 파일
+          cp ../v2-pm2-run-${{ env.PHASE }}.js ../artifact/
+          cp ../deploy.sh ../artifact/
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -160,9 +165,9 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_S3_SECRET_KEY_DEV }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Upload dist to S3
+      - name: Upload artefacts to S3
         run: |
-          aws s3 cp --recursive ./parsing-api s3://$AWS_S3_BUCKET_NAME/$BUILD_DIR_NAME
+          aws s3 cp --recursive ../artifact s3://$AWS_S3_BUCKET_NAME/$BUILD_DIR_NAME
 
   # ---------------------------------------------------------------------------
   # push (Node 22.x LTS)
@@ -193,9 +198,6 @@ jobs:
       - name: npm ci (clean install)
         run: npm ci
 
-      #      - name: ESLint check
-      #        run: npm run lint
-
       - name: Create .env
         run: |
           touch .env
@@ -205,16 +207,17 @@ jobs:
           echo "== '\n' 인식 문제로 인해 재할당 =="
           echo FIREBASE_PRIVATE_KEY=${{ secrets.FIREBASE_PRIVATE_KEY }} >> .env
 
-      - name: Build (dev)
-        run: npm run build --if-present
+      - name: Build (prod)
+        run: npm run build:production --if-present
 
-      - name: Copy deploy artifacts
+      - name: Package artefacts
         run: |
-          cp ../v2-pm2-run-prod.js ./dist/
-          cp ../deploy.sh ./dist/
-
-      - name: Rename build directory
-        run: mv dist push
+          mkdir -p ../artifact/push
+          # webpack 번들에 모든 의존성 inline (native 의존 없음 → node_modules 불필요)
+          cp -r dist/. ../artifact/push/
+          # 공통 파일
+          cp ../v2-pm2-run-${{ env.PHASE }}.js ../artifact/
+          cp ../deploy.sh ../artifact/
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -223,6 +226,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_S3_SECRET_KEY_DEV }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Upload dist to S3
+      - name: Upload artefacts to S3
         run: |
-          aws s3 cp --recursive ./push s3://$AWS_S3_BUCKET_NAME/$BUILD_DIR_NAME
+          aws s3 cp --recursive ../artifact s3://$AWS_S3_BUCKET_NAME/$BUILD_DIR_NAME

--- a/deploy.sh
+++ b/deploy.sh
@@ -32,9 +32,9 @@ ls
 
 # parsing-api 가 새로 배포되었고 playwright runtime 이 ZIP 에 포함되었다면 Chromium 바이너리 설치.
 # 이미 받았으면 playwright 가 알아서 skip. 시스템 라이브러리(libnss3 등) 는 운영 셋업 1회로 분리.
-if [ -f "parsing-api/package.json" ] && grep -q '"playwright"' "parsing-api/package.json"; then
+if [ -f "parsing-api/package.json" ] && grep -q '"playwright":' "parsing-api/package.json"; then
   echo "******** Installing Playwright Chromium for parsing-api ********"
-  (cd parsing-api && npx --no-install playwright install chromium)
+  (cd parsing-api && npx --no-install playwright install chromium) || exit 1
 fi
 
 echo "******** PM2 script start ********"

--- a/deploy.sh
+++ b/deploy.sh
@@ -30,6 +30,13 @@ cd $DEPLOY_DIR || exit 1
 
 ls
 
+# parsing-api 가 새로 배포되었고 playwright runtime 이 ZIP 에 포함되었다면 Chromium 바이너리 설치.
+# 이미 받았으면 playwright 가 알아서 skip. 시스템 라이브러리(libnss3 등) 는 운영 셋업 1회로 분리.
+if [ -f "parsing-api/package.json" ] && grep -q '"playwright"' "parsing-api/package.json"; then
+  echo "******** Installing Playwright Chromium for parsing-api ********"
+  (cd parsing-api && npx --no-install playwright install chromium)
+fi
+
 echo "******** PM2 script start ********"
 # PM2 config symlink 구성
 rm -f "$PM2_CONFIG_LINK"

--- a/v2-pm2-run-dev.js
+++ b/v2-pm2-run-dev.js
@@ -2,16 +2,14 @@ module.exports = {
     /**
      * PM2 process definitions for Wishboard v2 (dev environment)
      *
-     * ▸ wishboard-v2-api-server-dev      : Java Spring Boot (single instance, fork mode)
+     * ▸ wishboard-v2-api-server-dev         : Java Spring Boot (single instance, fork mode)
      * ▸ wishboard-v2-parsing-api-server-dev : Node.js Parsing API (1 instance cluster)
-     * ▸ wishboard-v2-push-scheduler-dev  : Java Push‑Scheduler (1 instance cluster)
+     * ▸ wishboard-v2-push-scheduler-dev     : Node.js Push Scheduler (1 instance fork)
      *
-     * NOTE
-     * ────────────────────────────────────────────────────────────────
-     * 1) "cwd" is kept identical across apps; adjust if you relocate binaries.
-     * 2) "version" fields are placeholders – bump on every tagged release.
-     * 3) If push‑scheduler is actually a Node service, switch `script` to the
-     *    entry JS file and set `interpreter: 'node'`, `exec_mode: 'cluster'`.
+     * 디렉토리 구조 (current/):
+     *   ├── api/          server-2.0.0.jar
+     *   ├── parsing-api/  server.js + node_modules/playwright(+core)
+     *   └── push/         pushScheduler.js + vendors-*.js
      */
     apps: [
         /* ───────────────────────── Java API ───────────────────────── */
@@ -23,10 +21,10 @@ module.exports = {
                 '-Xms128m',
                 '-jar',
                 '-Duser.timezone=Asia/Seoul',
-                '/home/ubuntu/wishboard-v2/dev/current/server-2.0.0.jar', // TODO 버전 변경 시 여기 수정
+                '/home/ubuntu/wishboard-v2/dev/current/api/server-2.0.0.jar', // TODO 버전 변경 시 여기 수정
                 '--spring.profiles.active=dev'
             ],
-            cwd: '/home/ubuntu/wishboard-v2/dev/current',
+            cwd: '/home/ubuntu/wishboard-v2/dev/current/api',
             exec_mode: 'fork',
             instances: 1,
             namespace: 'api-server',
@@ -40,7 +38,7 @@ module.exports = {
             name: 'wishboard-v2-parsing-api-server-dev',
             script: './server.js',
             interpreter: 'node',
-            cwd: '/home/ubuntu/wishboard-v2/dev/current',
+            cwd: '/home/ubuntu/wishboard-v2/dev/current/parsing-api',
             namespace: 'parsing-api-server',
             version: '2.0.0', // TODO 버전 변경 시 여기 수정
             instances: 1,
@@ -52,12 +50,12 @@ module.exports = {
             watch: false
         },
 
-        /* ───────────────────────── Java Push Scheduler ───────────────────────── */
+        /* ───────────────────────── Node Push Scheduler ───────────────────────── */
         {
             name: 'wishboard-v2-push-scheduler-dev',
             script: './pushScheduler.js',
             interpreter: 'node',
-            cwd: '/home/ubuntu/wishboard-v2/dev/current',
+            cwd: '/home/ubuntu/wishboard-v2/dev/current/push',
             namespace: 'push-scheduler',
             version: '2.0.0',  // TODO 버전 변경 시 여기 수정
             instances: 1,

--- a/v2-pm2-run-prod.js
+++ b/v2-pm2-run-prod.js
@@ -2,16 +2,14 @@ module.exports = {
     /**
      * PM2 process definitions for Wishboard v2 (prod environment)
      *
-     * ▸ wishboard-v2-api-server-prod      : Java Spring Boot (single instance, fork mode)
+     * ▸ wishboard-v2-api-server-prod         : Java Spring Boot (single instance, fork mode)
      * ▸ wishboard-v2-parsing-api-server-prod : Node.js Parsing API (1 instance cluster)
-     * ▸ wishboard-v2-push-scheduler-prod  : Java Push‑Scheduler (1 instance cluster)
+     * ▸ wishboard-v2-push-scheduler-prod     : Node.js Push Scheduler (1 instance cluster)
      *
-     * NOTE
-     * ────────────────────────────────────────────────────────────────
-     * 1) "cwd" is kept identical across apps; adjust if you relocate binaries.
-     * 2) "version" fields are placeholders – bump on every tagged release.
-     * 3) If push‑scheduler is actually a Node service, switch `script` to the
-     *    entry JS file and set `interpreter: 'node'`, `exec_mode: 'cluster'`.
+     * 디렉토리 구조 (current/):
+     *   ├── api/          server-2.0.0.jar
+     *   ├── parsing-api/  server.js + node_modules/playwright(+core)
+     *   └── push/         pushScheduler.js + vendors-*.js
      */
     apps: [
         /* ───────────────────────── Java API ───────────────────────── */
@@ -23,10 +21,10 @@ module.exports = {
                 '-Xms128m',
                 '-jar',
                 '-Duser.timezone=Asia/Seoul',
-                '/home/ubuntu/wishboard-v2/prod/current/server-2.0.0.jar', // TODO 버전 변경 시 여기 수정
+                '/home/ubuntu/wishboard-v2/prod/current/api/server-2.0.0.jar', // TODO 버전 변경 시 여기 수정
                 '--spring.profiles.active=prod'
             ],
-            cwd: '/home/ubuntu/wishboard-v2/prod/current',
+            cwd: '/home/ubuntu/wishboard-v2/prod/current/api',
             exec_mode: 'fork',
             instances: 1,
             namespace: 'api-server',
@@ -40,7 +38,7 @@ module.exports = {
             name: 'wishboard-v2-parsing-api-server-prod',
             script: './server.js',
             interpreter: 'node',
-            cwd: '/home/ubuntu/wishboard-v2/prod/current',
+            cwd: '/home/ubuntu/wishboard-v2/prod/current/parsing-api',
             namespace: 'parsing-api-server',
             version: '2.0.0', // TODO 버전 변경 시 여기 수정
             instances: 1,
@@ -52,12 +50,12 @@ module.exports = {
             watch: false
         },
 
-        /* ───────────────────────── Java Push Scheduler ───────────────────────── */
+        /* ───────────────────────── Node Push Scheduler ───────────────────────── */
         {
             name: 'wishboard-v2-push-scheduler-prod',
             script: './pushScheduler.js',
             interpreter: 'node',
-            cwd: '/home/ubuntu/wishboard-v2/prod/current',
+            cwd: '/home/ubuntu/wishboard-v2/prod/current/push',
             namespace: 'push-scheduler',
             version: '2.0.0',  // TODO 버전 변경 시 여기 수정
             instances: 1,

--- a/v2-pm2-run-prod.js
+++ b/v2-pm2-run-prod.js
@@ -4,7 +4,7 @@ module.exports = {
      *
      * ▸ wishboard-v2-api-server-prod         : Java Spring Boot (single instance, fork mode)
      * ▸ wishboard-v2-parsing-api-server-prod : Node.js Parsing API (1 instance cluster)
-     * ▸ wishboard-v2-push-scheduler-prod     : Node.js Push Scheduler (1 instance cluster)
+     * ▸ wishboard-v2-push-scheduler-prod     : Node.js Push Scheduler (1 instance fork)
      *
      * 디렉토리 구조 (current/):
      *   ├── api/          server-2.0.0.jar
@@ -59,7 +59,7 @@ module.exports = {
             namespace: 'push-scheduler',
             version: '2.0.0',  // TODO 버전 변경 시 여기 수정
             instances: 1,
-            exec_mode: 'cluster',
+            exec_mode: 'fork',
             wait_ready: true,
             listen_timeout: 50000,
             kill_timeout: 5000,


### PR DESCRIPTION
## Summary

운영 EC2 의 `current/` 디렉토리에 `api`, `parsing-api`, `push` 산출물이 한꺼번에 펼쳐져 있어서 다음 문제가 있었음:

1. **`parsing-api`의 `require('playwright')`가 runtime에 실패** — webpack externals로 분리한 `playwright`가 배포 산출물에 포함되지 않음 ([discussion](https://github.com/hyeeyoung/wishboard-server-v2/pull/13))
2. 모듈 간 파일 충돌 위험 (예: 향후 push 모듈에 native dep 도입 시)
3. PM2 ecosystem의 `cwd` 가 모든 모듈에 대해 동일해서 어떤 디렉토리에 무엇이 있는지 모호

본 PR은 다음 구조로 정비합니다:

```
{deploy_dir}/
├── deploy.sh
├── ecosystem.config.js → v2-pm2-run-{phase}.js (symlink)
├── v2-pm2-run-{phase}.js
├── api/
│   └── server-2.0.0.jar
├── parsing-api/
│   ├── server.js              (webpack 번들)
│   ├── package.json
│   ├── package-lock.json
│   └── node_modules/          (playwright + playwright-core, prune 후)
└── push/
    ├── pushScheduler.js       (webpack 번들)
    └── vendors-*.js           (webpack split chunks)
```

## 커밋

| 해시 | 메시지 |
|---|---|
| `b80d5ab` | `[chore] PM2 ecosystem 모듈별 디렉토리(cwd) 분리` |
| `389e49f` | `[chore] deploy.sh 에 parsing-api Playwright Chromium 자동 설치 단계 추가` |
| `bc70204` | `[ci] 빌드 아티팩트를 모듈별 폴더 구조로 분리하고 parsing-api 에 node_modules 포함` |

### 주요 변경

- **PM2 ecosystem (`v2-pm2-run-{dev,prod}.js`)**: 각 앱의 `cwd` 를 `current/api`, `current/parsing-api`, `current/push` 로 분리. jar 경로도 `current/api/server-2.0.0.jar` 로 갱신.
- **`deploy.sh`**: ZIP 다운로드 후 `parsing-api/package.json` 에 `playwright` 가 있으면 `npx playwright install chromium` 자동 실행. 이미 받았으면 playwright 가 skip.
- **GitHub Actions**:
  - `env.PHASE` 변수 도입 — `v2-pm2-run-{phase}.js` 동적 선택 (이전엔 prod 워크플로가 `v2-pm2-run-dev.js` 를 가져오는 버그 있었음)
  - parsing-api 빌드 후 `npm prune --omit=dev` → dev 의존성 제거하고 `node_modules` 를 artifact 에 포함
  - artifact 디렉토리에 모듈별 prefix 로 정리 후 S3 cp → 운영에서 받을 때 자동으로 모듈 폴더로 분리됨
  - push/parsing-api prod 빌드를 `npm run build:production` 으로 변경 (이전엔 dev 모드로 빌드되던 버그)
  - actions/checkout, setup-java 등 v3 → v4 일괄 업그레이드

## 운영 EC2 마이그레이션 (1회성 수동 작업)

본 PR 머지 → 첫 배포 후 한 번만 수행:

```bash
# 1) Chromium 시스템 라이브러리 (1회) — 매 배포마다 받지 않도록 분리
sudo npx playwright install-deps chromium

# 2) 옵션 A로 임시 부착했던 node_modules/playwright 정리 (정식 배포에 포함되므로 불필요)
cd ~/wishboard-v2/{dev,prod}/current
rm -rf node_modules package.json package-lock.json   # 루트의 임시 파일들

# 3) 기존 루트에 펼쳐졌던 server.js, pushScheduler.js, server-*.jar 등 정리
rm -f server.js server.js.LICENSE.txt pushScheduler.js vendors-*.pushScheduler.js \
      server-2.0.0.jar server-2.0.0-plain.jar \
      node_modules_*.pushScheduler.js
# 새 배포는 current/{api,parsing-api,push}/ 하위에 정리되어 들어옴
```

## Test plan

### 자동 검증 (완료)
- [x] yaml syntax (python yaml.safe_load) 통과 - dev/prod 둘 다

### 운영 검증 필요
- [ ] **dev 워크플로 1회 트리거**해서 S3 업로드 구조 확인 (`aws s3 ls s3://$BUCKET/$BUILD_DIR_NAME/` 에 `api/`, `parsing-api/`, `push/`, `deploy.sh`, `v2-pm2-run-dev.js` 가 보여야 함)
- [ ] dev EC2 에서 deploy.sh 실행 → `current/api/`, `current/parsing-api/node_modules/playwright/`, `current/push/` 확인
- [ ] dev `pm2 reload` 후 세 프로세스 모두 정상 기동
- [ ] dev parsing-api 가 헤드리스 호출 가능한지 — 실제 SPA URL 1개 요청해서 `parser_type=headless_fallback` 로그 확인
- [ ] dev 1주 모니터링 후 prod 머지

## 잔존 이슈 (별도 안건)

- `npm audit` 취약점은 별도 PR
- `dorny/paths-filter@v3` 는 아직 최신 (v3 유지)
- 인스턴스 메모리 한도(`max_memory_restart`) 추가 검토 — Chromium 누수 대비

## 참고

- 옵션 A로 운영 긴급 픽스가 이미 적용된 상태 — 본 PR이 정식 해결
- PR #13 plan §4.3 (webpack externals 결정) / §9 (인프라 안건 분리) 의 후속 작업

🤖 Generated with [Claude Code](https://claude.com/claude-code)