### PR TITLE
[parsing-api/api] 헤드리스 follow-up 5개 이슈 일괄 처리 (#18 #19 #20 #21 #22)

### DIFF
--- a/api/src/main/java/com/wishboard/server/item/presentation/dto/request/CreateItemRequest.java
+++ b/api/src/main/java/com/wishboard/server/item/presentation/dto/request/CreateItemRequest.java
@@ -25,7 +25,7 @@ public record CreateItemRequest(
 	String itemMemo,
 
 	@Schema(description = "itemUrl", example = "https://naver.com")
-	@Size(max = 1024, message = "{item.itemUrl.max")
+	@Size(max = 2048, message = "{item.itemUrl.max")
 	String itemUrl,
 
 	@Schema(description = "알림 타입", example = "REMINDER")

--- a/api/src/main/java/com/wishboard/server/item/presentation/dto/request/CreateItemRequest.java
+++ b/api/src/main/java/com/wishboard/server/item/presentation/dto/request/CreateItemRequest.java
@@ -25,7 +25,7 @@ public record CreateItemRequest(
 	String itemMemo,
 
 	@Schema(description = "itemUrl", example = "https://naver.com")
-	@Size(max = 2048, message = "{item.itemUrl.max")
+	@Size(max = 2048, message = "{item.itemUrl.max}")
 	String itemUrl,
 
 	@Schema(description = "알림 타입", example = "REMINDER")

--- a/api/src/main/resources/sql/schema.sql
+++ b/api/src/main/resources/sql/schema.sql
@@ -64,7 +64,7 @@ CREATE TABLE `items` (
                          `item_memo` text ,
                          `item_name` varchar(512) NOT NULL,
                          `item_price` varchar(255) NOT NULL,
-                         `item_url` varchar(1024) DEFAULT NULL,
+                         `item_url` varchar(2048) DEFAULT NULL,
                          `item_status` varchar(45) NOT NULL DEFAULT 'WISH';
                          `folder_id` bigint DEFAULT NULL,
                          `user_id` bigint NOT NULL,

--- a/deploy.sh
+++ b/deploy.sh
@@ -32,9 +32,13 @@ ls
 
 # parsing-api 가 새로 배포되었고 playwright runtime 이 ZIP 에 포함되었다면 Chromium 바이너리 설치.
 # 이미 받았으면 playwright 가 알아서 skip. 시스템 라이브러리(libnss3 등) 는 운영 셋업 1회로 분리.
+#
+# aws s3 cp --recursive 가 node_modules/.bin/* 의 심볼릭 링크와 execute bit 를
+# 보존하지 않으므로 npx / .bin 경로 대신 node 로 cli.js 를 직접 호출한다.
+# (이 방식은 execute 권한 체크 / 링크 dereference 둘 다 우회됨)
 if [ -f "parsing-api/package.json" ] && grep -q '"playwright":' "parsing-api/package.json"; then
   echo "******** Installing Playwright Chromium for parsing-api ********"
-  (cd parsing-api && npx --no-install playwright install chromium) || exit 1
+  (cd parsing-api && node node_modules/playwright/cli.js install chromium) || exit 1
 fi
 
 echo "******** PM2 script start ********"

--- a/parsing-api/src/controllers/itemController.js
+++ b/parsing-api/src/controllers/itemController.js
@@ -1,5 +1,6 @@
 const { onBindParsingType, normalizeUrl } = require('../lib/parser');
 const { parseWithHeadless } = require('../lib/headlessParser');
+const { mergeResults } = require('../lib/parser/utils');
 const logger = require('../config/winston');
 const { BadRequest } = require('../utils/errors');
 const {
@@ -14,6 +15,14 @@ const isEmptyResult = (data) => {
   }
   const { item_img, item_name, item_price } = data;
   return !item_img && !item_name && !item_price;
+};
+
+// itemPrice 만 결손이고 다른 필드는 있을 때 → 헤드리스로 가격만 보강.
+// 정적이 부분 성공(name+img는 잡았지만 가격 미달)한 케이스를 위한 판정.
+const needsPriceFallback = (data) => {
+  if (!data || typeof data !== 'object') return false;
+  if (isEmptyResult(data)) return false;
+  return !data.item_price;
 };
 
 const isValidUrl = (url) => {
@@ -49,6 +58,10 @@ module.exports = {
       if (isEmptyResult(data)) {
         parserType = 'headless_fallback';
         data = await parseWithHeadless(site);
+      } else if (needsPriceFallback(data)) {
+        parserType = 'static_with_price_fallback';
+        const headlessData = await parseWithHeadless(site);
+        data = mergeResults(data, headlessData);
       }
 
       logger.info(

--- a/parsing-api/src/controllers/itemController.js
+++ b/parsing-api/src/controllers/itemController.js
@@ -1,4 +1,4 @@
-const { onBindParsingType } = require('../lib/parser');
+const { onBindParsingType, normalizeUrl } = require('../lib/parser');
 const { parseWithHeadless } = require('../lib/headlessParser');
 const logger = require('../config/winston');
 const { BadRequest } = require('../utils/errors');
@@ -67,6 +67,8 @@ module.exports = {
           itemImageUrl: data.item_img,
           itemName: data.item_name,
           itemPrice: data.item_price,
+          // 추적 파라미터 제거된 정규화 URL — 클라이언트가 백엔드 저장 시 이 값 사용 권장
+          itemUrl: normalizeUrl(site),
         },
       });
     } catch (err) {

--- a/parsing-api/src/lib/headlessParser.js
+++ b/parsing-api/src/lib/headlessParser.js
@@ -24,6 +24,7 @@ const {
   getExtractorBySiteType,
   getRandomUserAgent,
 } = require('./parser');
+const { emptyResult, looksLikeBotBlock } = require('./parser/utils');
 
 const PAGE_GOTO_TIMEOUT_MS = 8000;
 
@@ -74,14 +75,17 @@ const parseWithHeadless = async (url) => {
     const html = await page.content();
     const siteType = resolveSiteType(url);
     const extract = getExtractorBySiteType(siteType);
-    return extract(html, url);
+    const result = extract(html, url);
+    if (looksLikeBotBlock(result)) {
+      logger.warn(
+        `[headlessParser] bot block detected for ${url}: name="${result.item_name}"`,
+      );
+      return emptyResult();
+    }
+    return result;
   } catch (err) {
     logger.error(`[headlessParser] error for ${url}: ${err?.stack || err}`);
-    return {
-      item_img: undefined,
-      item_name: undefined,
-      item_price: undefined,
-    };
+    return emptyResult();
   } finally {
     if (context) {
       try {

--- a/parsing-api/src/lib/headlessParser.js
+++ b/parsing-api/src/lib/headlessParser.js
@@ -39,6 +39,8 @@ const parseWithHeadless = async (url) => {
   await acquireSlot();
 
   let context;
+  let page;
+  let response;
   try {
     const browser = await getBrowser();
     context = await browser.newContext({
@@ -60,16 +62,18 @@ const parseWithHeadless = async (url) => {
       }
     });
 
-    const page = await context.newPage();
+    page = await context.newPage();
     page.setDefaultTimeout(PAGE_GOTO_TIMEOUT_MS);
 
     try {
-      await page.goto(url, {
+      response = await page.goto(url, {
         waitUntil: 'domcontentloaded',
         timeout: PAGE_GOTO_TIMEOUT_MS,
       });
     } catch (gotoErr) {
-      logger.warn(`[headlessParser] goto failed for ${url}: ${gotoErr.message}`);
+      logger.warn(
+        `[headlessParser] goto failed for ${url}: ${gotoErr.message} final_url=${page.url?.()}`,
+      );
     }
 
     const html = await page.content();
@@ -78,13 +82,17 @@ const parseWithHeadless = async (url) => {
     const result = extract(html, url);
     if (looksLikeBotBlock(result)) {
       logger.warn(
-        `[headlessParser] bot block detected for ${url}: name="${result.item_name}"`,
+        `[headlessParser] bot block detected for ${url}: name="${result.item_name}" ` +
+          `status=${response?.status?.() ?? 'unknown'} final_url=${page.url?.()}`,
       );
       return emptyResult();
     }
     return result;
   } catch (err) {
-    logger.error(`[headlessParser] error for ${url}: ${err?.stack || err}`);
+    logger.error(
+      `[headlessParser] error for ${url}: status=${response?.status?.() ?? 'unknown'} ` +
+        `final_url=${page?.url?.() ?? 'unknown'} stack=${err?.stack || err}`,
+    );
     return emptyResult();
   } finally {
     if (context) {

--- a/parsing-api/src/lib/parser/index.js
+++ b/parsing-api/src/lib/parser/index.js
@@ -1,5 +1,5 @@
 const { getHtml, userAgents, getRandomUserAgent } = require('./http');
-const { emptyResult } = require('./utils');
+const { emptyResult, normalizeUrl } = require('./utils');
 
 const { extractFromGeneralHtml } = require('./extractors/general');
 const { extractFromMusinsaHtml } = require('./extractors/musinsa');
@@ -86,4 +86,5 @@ module.exports = {
   getExtractorBySiteType,
   userAgents,
   getRandomUserAgent,
+  normalizeUrl,
 };

--- a/parsing-api/src/lib/parser/utils.js
+++ b/parsing-api/src/lib/parser/utils.js
@@ -129,6 +129,20 @@ const normalizeUrl = (rawUrl) => {
   }
 };
 
+/**
+ * 두 추출 결과를 머지. primary 의 falsy 필드를 secondary 값으로 채운다.
+ * 빈 문자열·undefined·null 모두 falsy 로 처리.
+ */
+const mergeResults = (primary, secondary) => {
+  const p = primary || {};
+  const s = secondary || {};
+  return {
+    item_img: p.item_img || s.item_img,
+    item_name: p.item_name || s.item_name,
+    item_price: p.item_price || s.item_price,
+  };
+};
+
 module.exports = {
   getPriceWithoutString,
   emptyResult,
@@ -137,4 +151,5 @@ module.exports = {
   looksLikeBotBlock,
   BOT_BLOCK_PATTERNS,
   normalizeUrl,
+  mergeResults,
 };

--- a/parsing-api/src/lib/parser/utils.js
+++ b/parsing-api/src/lib/parser/utils.js
@@ -59,6 +59,76 @@ const looksLikeBotBlock = (result) => {
   return BOT_BLOCK_PATTERNS.some((pattern) => pattern.test(name));
 };
 
+// URL 추적 파라미터 블랙리스트.
+// - 정확 매치 또는 startsWith 매치 (utm_* 류).
+// - 도메인별 화이트리스트보다 블랙리스트가 안전: 미지원 도메인의 상품 ID 파라미터를 실수로 제거하지 않도록.
+const TRACKING_PARAM_PREFIXES = ['utm_'];
+const TRACKING_PARAM_EXACT = new Set([
+  // 광고 클릭 추적
+  'fbclid',
+  'gclid',
+  'dclid',
+  // 광고 / 추천 트래킹
+  'businessTracking',
+  'gaListId',
+  'gaListName',
+  'ciderListId',
+  'ciderListName',
+  'NaPm',
+  // Shopcider 류
+  'linkUrl',
+  'operationContent',
+  'operationImage',
+  'operationpageTitle',
+  'operationPosition',
+  'operationType',
+  'productPosition',
+  // 쿠팡 류
+  '_NC',
+  'wPcid',
+  'wRef',
+  'wTime',
+  'redirect',
+  'addtag',
+  'ctag',
+  'lptag',
+  'itime',
+  'pageType',
+  'pageValue',
+]);
+
+const isTrackingParam = (key) => {
+  if (TRACKING_PARAM_EXACT.has(key)) return true;
+  return TRACKING_PARAM_PREFIXES.some((prefix) => key.startsWith(prefix));
+};
+
+/**
+ * URL 에서 추적 파라미터를 제거한 정규화 URL 반환.
+ * 파싱 실패하면 원본 그대로 반환.
+ * @param {string} rawUrl
+ * @returns {string}
+ */
+const normalizeUrl = (rawUrl) => {
+  if (typeof rawUrl !== 'string' || !rawUrl) {
+    return rawUrl;
+  }
+  try {
+    const url = new URL(rawUrl);
+    const keysToDelete = [];
+    for (const key of url.searchParams.keys()) {
+      if (isTrackingParam(key)) {
+        keysToDelete.push(key);
+      }
+    }
+    for (const key of keysToDelete) {
+      url.searchParams.delete(key);
+    }
+    return url.toString();
+  } catch (e) {
+    return rawUrl;
+  }
+};
+
 module.exports = {
   getPriceWithoutString,
   emptyResult,
@@ -66,4 +136,5 @@ module.exports = {
   titleFallback,
   looksLikeBotBlock,
   BOT_BLOCK_PATTERNS,
+  normalizeUrl,
 };

--- a/parsing-api/src/lib/parser/utils.js
+++ b/parsing-api/src/lib/parser/utils.js
@@ -33,9 +33,32 @@ const titleFallback = ($) => {
   return text || undefined;
 };
 
+// 봇 차단 / 대기 페이지 패턴. itemName 에 매치되면 추출 결과를 신뢰할 수 없는 것으로 본다.
+const BOT_BLOCK_PATTERNS = [
+  /access\s*denied/i,
+  /forbidden/i,
+  /\b403\b/,
+  /bot\s*detection/i,
+];
+
+/**
+ * 추출된 itemName 이 봇 차단 / 인증 거부 페이지의 타이틀인지 판정.
+ * @param {{item_name?: string|undefined} | null | undefined} result
+ * @returns {boolean}
+ */
+const looksLikeBotBlock = (result) => {
+  const name = result?.item_name;
+  if (typeof name !== 'string' || !name.trim()) {
+    return false;
+  }
+  return BOT_BLOCK_PATTERNS.some((pattern) => pattern.test(name));
+};
+
 module.exports = {
   getPriceWithoutString,
   emptyResult,
   extractOgMeta,
   titleFallback,
+  looksLikeBotBlock,
+  BOT_BLOCK_PATTERNS,
 };

--- a/parsing-api/src/lib/parser/utils.js
+++ b/parsing-api/src/lib/parser/utils.js
@@ -39,6 +39,11 @@ const BOT_BLOCK_PATTERNS = [
   /forbidden/i,
   /\b403\b/,
   /bot\s*detection/i,
+  /잠시만\s*기다리(십시오|세요)/, // Gmarket 등의 봇 검증 대기 페이지
+  /just\s*a\s*moment/i, // Cloudflare 대기 페이지
+  /please\s*wait/i,
+  /checking\s*your\s*browser/i,
+  /verification/i,
 ];
 
 /**


### PR DESCRIPTION
## Summary

운영 dev 테스트에서 발견된 헤드리스 파싱 실패 4건 + 흐름 개선 1건을 한 PR 에서 **이슈별 커밋 단위로** 처리합니다.

| 이슈 | 커밋 | 종류 |
|---|---|---|
| #18 | `c4e3f3e` `[fix] 헤드리스 fallback 추출 결과의 봇 차단 페이지 사후 검증` | 헤드리스 결과 검증 |
| #19 | `b8349b1` `[fix] BOT_BLOCK_PATTERNS 에 한국어 대기 메시지 등 추가` | 패턴 확장 |
| #20 | `1741644` `[chore] 헤드리스 파싱 실패 시 디버깅 컨텍스트 로그 추가` | 디버깅 |
| #21 | `cb737d0` `[fix] itemUrl 추적 파라미터 정규화 및 길이 한도 2048 로 증가` | URL 정규화 |
| #22 | `31ae0e0` `[feat] 정적 결과 itemPrice 결손 시 헤드리스로 가격 보강 fallback 도입` | 흐름 개선 |

## 커밋별 변경

### #18 — 봇 차단 페이지 사후 검증 (COS)
- `parser/utils.js` 에 `looksLikeBotBlock(result)` + `BOT_BLOCK_PATTERNS` 신규
- `headlessParser.js` 에서 추출 직후 검증 → 매치 시 `emptyResult()` 반환
- 패턴: `Access Denied`, `Forbidden`, `403`, `bot detection`

### #19 — 한국어 대기 메시지 패턴 추가 (Gmarket)
- `잠시만 기다리(십시오|세요)`, `Just a moment`, `Please wait`, `Checking your browser`, `verification` 패턴 추가

### #20 — 알리익스프레스 디버깅 로그 보강
- `headlessParser.js` 에 `response.status()`, `page.url()` 컨텍스트 로깅
- 운영 dev 에서 데이터 수집 후 후속 결정 (stealth / timeout / 미지원 명시)

### #21 — itemUrl 정규화 + 길이 한도 (Shopcider)
- **parsing-api**: `normalizeUrl(rawUrl)` 신규. utm_*, fbclid, businessTracking, NaPm, operation*, _NC, wPcid 등 추적 파라미터 블랙리스트 제거
- **parsing-api**: `/parse` 응답 `data.itemUrl` 필드 추가 — 클라이언트가 백엔드 저장 시 사용 권장
- **api**: `CreateItemRequest.@Size(max=1024)` → `2048` (안전망)
- **api**: `schema.sql` `item_url varchar(1024)` → `varchar(2048)`

### #22 — itemPrice 결손 시 헤드리스 보강
- `needsPriceFallback(data)` + `mergeResults(primary, secondary)` 신규
- 흐름:
  ```text
  정적 → isEmptyResult? → yes: 전체 headless fallback
                       → no: needsPriceFallback? → yes: headless 호출 후 price merge
                                                → no:  static 그대로
  ```
- `parser_type` 라벨 추가: `static_with_price_fallback`

## Test plan

### 자동 검증 (완료)
- [x] `npm run build` 통과 (모든 커밋 직후)
- [x] `looksLikeBotBlock` 10개 단위 케이스 (영어 + 한국어 패턴)
- [x] `normalizeUrl` 6개 단위 케이스 (Shopcider / utm / NaPm / 정상 / 잘못된 URL / 빈 문자열)
- [x] `mergeResults` 4개 단위 케이스 (deepStrictEqual)

### 운영 수동 검증 (배포 후)
- [ ] COS 상품 URL → `parser_type=headless_fallback` 후 봇 차단 감지 → 204 NO_CONTENT
- [ ] Gmarket 상품 URL → 대기 페이지 감지 → 204
- [ ] 알리익스프레스 URL → 새 로그(status, final_url) 수집 → 본 이슈 코멘트에 정리
- [ ] Shopcider URL → `/parse` 응답에 `itemUrl` 필드 포함 + 정규화로 1024자 이내
- [ ] 정적으로 가격 못 잡던 사이트(29CM / 제시믹스 / EQL / SSG) → `parser_type=static_with_price_fallback` 로 가격 보강
- [ ] 정적으로 가격까지 잡던 사이트(11번가) → `parser_type=static` (헤드리스 호출 없음)

### 운영 DB 수동 작업 필요 (배포 전)
```sql
ALTER TABLE items MODIFY COLUMN item_url varchar(2048);
```

### 클라이언트 측 후속 작업 (별도 저장소 / 별도 이슈)
- 클라이언트가 `/parse` 응답의 `data.itemUrl` 을 (사용자 입력 raw URL 대신) 백엔드 저장 호출에 사용

## 관련 이슈

closes #18, closes #19, closes #21, closes #22
ref #20 (디버깅 로그 보강만 — 운영 데이터 수집 후 후속 결정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)