### PR TITLE
Merge

### DIFF
--- a/api/src/main/java/com/wishboard/server/item/presentation/dto/request/CreateItemRequest.java
+++ b/api/src/main/java/com/wishboard/server/item/presentation/dto/request/CreateItemRequest.java
@@ -25,7 +25,7 @@ public record CreateItemRequest(
 	String itemMemo,
 
 	@Schema(description = "itemUrl", example = "https://naver.com")
-	@Size(max = 1024, message = "{item.itemUrl.max")
+	@Size(max = 2048, message = "{item.itemUrl.max}")
 	String itemUrl,
 
 	@Schema(description = "알림 타입", example = "REMINDER")

--- a/api/src/main/resources/sql/schema.sql
+++ b/api/src/main/resources/sql/schema.sql
@@ -64,7 +64,7 @@ CREATE TABLE `items` (
                          `item_memo` text ,
                          `item_name` varchar(512) NOT NULL,
                          `item_price` varchar(255) NOT NULL,
-                         `item_url` varchar(1024) DEFAULT NULL,
+                         `item_url` varchar(2048) DEFAULT NULL,
                          `item_status` varchar(45) NOT NULL DEFAULT 'WISH';
                          `folder_id` bigint DEFAULT NULL,
                          `user_id` bigint NOT NULL,

--- a/deploy.sh
+++ b/deploy.sh
@@ -32,9 +32,13 @@ ls
 
 # parsing-api 가 새로 배포되었고 playwright runtime 이 ZIP 에 포함되었다면 Chromium 바이너리 설치.
 # 이미 받았으면 playwright 가 알아서 skip. 시스템 라이브러리(libnss3 등) 는 운영 셋업 1회로 분리.
+#
+# aws s3 cp --recursive 가 node_modules/.bin/* 의 심볼릭 링크와 execute bit 를
+# 보존하지 않으므로 npx / .bin 경로 대신 node 로 cli.js 를 직접 호출한다.
+# (이 방식은 execute 권한 체크 / 링크 dereference 둘 다 우회됨)
 if [ -f "parsing-api/package.json" ] && grep -q '"playwright":' "parsing-api/package.json"; then
   echo "******** Installing Playwright Chromium for parsing-api ********"
-  (cd parsing-api && npx --no-install playwright install chromium) || exit 1
+  (cd parsing-api && node node_modules/playwright/cli.js install chromium) || exit 1
 fi
 
 echo "******** PM2 script start ********"

--- a/parsing-api/src/controllers/itemController.js
+++ b/parsing-api/src/controllers/itemController.js
@@ -1,5 +1,6 @@
-const { onBindParsingType } = require('../lib/parser');
+const { onBindParsingType, normalizeUrl } = require('../lib/parser');
 const { parseWithHeadless } = require('../lib/headlessParser');
+const { mergeResults } = require('../lib/parser/utils');
 const logger = require('../config/winston');
 const { BadRequest } = require('../utils/errors');
 const {
@@ -14,6 +15,14 @@ const isEmptyResult = (data) => {
   }
   const { item_img, item_name, item_price } = data;
   return !item_img && !item_name && !item_price;
+};
+
+// itemPrice 만 결손이고 다른 필드는 있을 때 → 헤드리스로 가격만 보강.
+// 정적이 부분 성공(name+img는 잡았지만 가격 미달)한 케이스를 위한 판정.
+const needsPriceFallback = (data) => {
+  if (!data || typeof data !== 'object') return false;
+  if (isEmptyResult(data)) return false;
+  return !data.item_price;
 };
 
 const isValidUrl = (url) => {
@@ -49,6 +58,10 @@ module.exports = {
       if (isEmptyResult(data)) {
         parserType = 'headless_fallback';
         data = await parseWithHeadless(site);
+      } else if (needsPriceFallback(data)) {
+        parserType = 'static_with_price_fallback';
+        const headlessData = await parseWithHeadless(site);
+        data = mergeResults(data, headlessData);
       }
 
       logger.info(
@@ -67,6 +80,8 @@ module.exports = {
           itemImageUrl: data.item_img,
           itemName: data.item_name,
           itemPrice: data.item_price,
+          // 추적 파라미터 제거된 정규화 URL — 클라이언트가 백엔드 저장 시 이 값 사용 권장
+          itemUrl: normalizeUrl(site),
         },
       });
     } catch (err) {

--- a/parsing-api/src/lib/headlessParser.js
+++ b/parsing-api/src/lib/headlessParser.js
@@ -24,6 +24,7 @@ const {
   getExtractorBySiteType,
   getRandomUserAgent,
 } = require('./parser');
+const { emptyResult, looksLikeBotBlock } = require('./parser/utils');
 
 const PAGE_GOTO_TIMEOUT_MS = 8000;
 
@@ -38,6 +39,8 @@ const parseWithHeadless = async (url) => {
   await acquireSlot();
 
   let context;
+  let page;
+  let response;
   try {
     const browser = await getBrowser();
     context = await browser.newContext({
@@ -59,29 +62,38 @@ const parseWithHeadless = async (url) => {
       }
     });
 
-    const page = await context.newPage();
+    page = await context.newPage();
     page.setDefaultTimeout(PAGE_GOTO_TIMEOUT_MS);
 
     try {
-      await page.goto(url, {
+      response = await page.goto(url, {
         waitUntil: 'domcontentloaded',
         timeout: PAGE_GOTO_TIMEOUT_MS,
       });
     } catch (gotoErr) {
-      logger.warn(`[headlessParser] goto failed for ${url}: ${gotoErr.message}`);
+      logger.warn(
+        `[headlessParser] goto failed for ${url}: ${gotoErr.message} final_url=${page.url?.()}`,
+      );
     }
 
     const html = await page.content();
     const siteType = resolveSiteType(url);
     const extract = getExtractorBySiteType(siteType);
-    return extract(html, url);
+    const result = extract(html, url);
+    if (looksLikeBotBlock(result)) {
+      logger.warn(
+        `[headlessParser] bot block detected for ${url}: name="${result.item_name}" ` +
+          `status=${response?.status?.() ?? 'unknown'} final_url=${page.url?.()}`,
+      );
+      return emptyResult();
+    }
+    return result;
   } catch (err) {
-    logger.error(`[headlessParser] error for ${url}: ${err?.stack || err}`);
-    return {
-      item_img: undefined,
-      item_name: undefined,
-      item_price: undefined,
-    };
+    logger.error(
+      `[headlessParser] error for ${url}: status=${response?.status?.() ?? 'unknown'} ` +
+        `final_url=${page?.url?.() ?? 'unknown'} stack=${err?.stack || err}`,
+    );
+    return emptyResult();
   } finally {
     if (context) {
       try {

--- a/parsing-api/src/lib/parser/index.js
+++ b/parsing-api/src/lib/parser/index.js
@@ -1,5 +1,5 @@
 const { getHtml, userAgents, getRandomUserAgent } = require('./http');
-const { emptyResult } = require('./utils');
+const { emptyResult, normalizeUrl } = require('./utils');
 
 const { extractFromGeneralHtml } = require('./extractors/general');
 const { extractFromMusinsaHtml } = require('./extractors/musinsa');
@@ -86,4 +86,5 @@ module.exports = {
   getExtractorBySiteType,
   userAgents,
   getRandomUserAgent,
+  normalizeUrl,
 };

--- a/parsing-api/src/lib/parser/utils.js
+++ b/parsing-api/src/lib/parser/utils.js
@@ -33,9 +33,123 @@ const titleFallback = ($) => {
   return text || undefined;
 };
 
+// 봇 차단 / 대기 페이지 패턴. itemName 에 매치되면 추출 결과를 신뢰할 수 없는 것으로 본다.
+const BOT_BLOCK_PATTERNS = [
+  /access\s*denied/i,
+  /forbidden/i,
+  /\b403\b/,
+  /bot\s*detection/i,
+  /잠시만\s*기다리(십시오|세요)/, // Gmarket 등의 봇 검증 대기 페이지
+  /just\s*a\s*moment/i, // Cloudflare 대기 페이지
+  /please\s*wait/i,
+  /checking\s*your\s*browser/i,
+  /verification/i,
+];
+
+/**
+ * 추출된 itemName 이 봇 차단 / 인증 거부 페이지의 타이틀인지 판정.
+ * @param {{item_name?: string|undefined} | null | undefined} result
+ * @returns {boolean}
+ */
+const looksLikeBotBlock = (result) => {
+  const name = result?.item_name;
+  if (typeof name !== 'string' || !name.trim()) {
+    return false;
+  }
+  return BOT_BLOCK_PATTERNS.some((pattern) => pattern.test(name));
+};
+
+// URL 추적 파라미터 블랙리스트.
+// - 정확 매치 또는 startsWith 매치 (utm_* 류).
+// - 도메인별 화이트리스트보다 블랙리스트가 안전: 미지원 도메인의 상품 ID 파라미터를 실수로 제거하지 않도록.
+const TRACKING_PARAM_PREFIXES = ['utm_'];
+const TRACKING_PARAM_EXACT = new Set([
+  // 광고 클릭 추적
+  'fbclid',
+  'gclid',
+  'dclid',
+  // 광고 / 추천 트래킹
+  'businessTracking',
+  'gaListId',
+  'gaListName',
+  'ciderListId',
+  'ciderListName',
+  'NaPm',
+  // Shopcider 류
+  'linkUrl',
+  'operationContent',
+  'operationImage',
+  'operationpageTitle',
+  'operationPosition',
+  'operationType',
+  'productPosition',
+  // 쿠팡 류
+  '_NC',
+  'wPcid',
+  'wRef',
+  'wTime',
+  'redirect',
+  'addtag',
+  'ctag',
+  'lptag',
+  'itime',
+  'pageType',
+  'pageValue',
+]);
+
+const isTrackingParam = (key) => {
+  if (TRACKING_PARAM_EXACT.has(key)) return true;
+  return TRACKING_PARAM_PREFIXES.some((prefix) => key.startsWith(prefix));
+};
+
+/**
+ * URL 에서 추적 파라미터를 제거한 정규화 URL 반환.
+ * 파싱 실패하면 원본 그대로 반환.
+ * @param {string} rawUrl
+ * @returns {string}
+ */
+const normalizeUrl = (rawUrl) => {
+  if (typeof rawUrl !== 'string' || !rawUrl) {
+    return rawUrl;
+  }
+  try {
+    const url = new URL(rawUrl);
+    const keysToDelete = [];
+    for (const key of url.searchParams.keys()) {
+      if (isTrackingParam(key)) {
+        keysToDelete.push(key);
+      }
+    }
+    for (const key of keysToDelete) {
+      url.searchParams.delete(key);
+    }
+    return url.toString();
+  } catch (e) {
+    return rawUrl;
+  }
+};
+
+/**
+ * 두 추출 결과를 머지. primary 의 falsy 필드를 secondary 값으로 채운다.
+ * 빈 문자열·undefined·null 모두 falsy 로 처리.
+ */
+const mergeResults = (primary, secondary) => {
+  const p = primary || {};
+  const s = secondary || {};
+  return {
+    item_img: p.item_img || s.item_img,
+    item_name: p.item_name || s.item_name,
+    item_price: p.item_price || s.item_price,
+  };
+};
+
 module.exports = {
   getPriceWithoutString,
   emptyResult,
   extractOgMeta,
   titleFallback,
+  looksLikeBotBlock,
+  BOT_BLOCK_PATTERNS,
+  normalizeUrl,
+  mergeResults,
 };


### PR DESCRIPTION
* [fix] 헤드리스 fallback 추출 결과의 봇 차단 페이지 사후 검증 (#18)

COS 처럼 정적/헤드리스 모두 봇 차단되는 사이트에서 차단 페이지의 og:title 또는 <title> 텍스트가 itemName 으로 그대로 응답에 들어가던 문제를 해결.

- parsing-api/src/lib/parser/utils.js: looksLikeBotBlock(result) 헬퍼 추가. BOT_BLOCK_PATTERNS = [Access Denied, Forbidden, 403, bot detection]
- parsing-api/src/lib/headlessParser.js: extract() 직후 검증하여 패턴 매치 시 빈 결과로 처리. emptyResult() 헬퍼도 재사용 (중복 객체 리터럴 제거).

회귀 검증: 9개 단위 케이스 통과.

closes #18
ref #19 (같은 헬퍼에 한국어 대기 메시지 패턴 추가 예정)



* [fix] BOT_BLOCK_PATTERNS 에 한국어 대기 메시지 등 추가 (#19)

Gmarket 의 봇 검증 대기 페이지("잠시만 기다리십시오...") 와 Cloudflare 류 대기 페이지("Just a moment", "Please wait", "Checking your browser", "verification") 패턴을 사후 검증 헬퍼 #18 에 추가.

회귀 검증: 10개 단위 케이스 통과 (이전 4개 + 신규 6개).

closes #19

* [chore] 헤드리스 파싱 실패 시 디버깅 컨텍스트 로그 추가 (#20)

알리익스프레스처럼 원인이 불명확한 헤드리스 실패 케이스를 추적하기 위해
다음 컨텍스트를 로그에 함께 기록:

- HTTP response status (response.status())
- redirect 후 최종 URL (page.url())

봇 차단 감지 로그와 outer catch 모두에 동일하게 적용.

ref #20 — 디버깅 로그 보강 후 운영 dev 에서 데이터 수집 → 후속 결정 (stealth 도입 / 도메인별 timeout / 미지원 명시 중 택일).

* [fix] itemUrl 추적 파라미터 정규화 및 길이 한도 2048 로 증가 (#21)

Shopcider 같이 추적 파라미터가 누적되어 URL 이 1024 자를 초과하면 백엔드
@Size 검증에 걸려 저장이 실패하던 문제를 해결.

parsing-api 변경:
- parsing-api/src/lib/parser/utils.js: normalizeUrl(rawUrl) 신규. utm_* 류 prefix + fbclid/gclid/businessTracking/NaPm/operation* 등 블랙리스트 파라미터 제거. 도메인별 화이트리스트보다 블랙리스트가 미지원 도메인의 상품 ID 파라미터를 실수로 제거하지 않아 안전.
- parsing-api/src/lib/parser/index.js: normalizeUrl re-export.
- parsing-api/src/controllers/itemController.js: 응답 data 에 itemUrl 필드 추가. 클라이언트는 사용자가 입력한 raw URL 대신 이 정규화된 URL 을 백엔드 저장 시 사용.

api 모듈 변경 (안전망):
- CreateItemRequest.java: @Size(max=1024) → @Size(max=2048).
- schema.sql: item_url varchar(1024) → varchar(2048).

운영 DB DDL 수동 적용 필요 (PR description 에 명시):
  ALTER TABLE items MODIFY COLUMN item_url varchar(2048);

회귀 검증: 6개 단위 케이스 통과 (Shopcider/utm/NaPm/정상/잘못된 URL/빈 문자열).

closes #21

* [feat] 정적 결과 itemPrice 결손 시 헤드리스로 가격 보강 fallback 도입 (#22)

현재 흐름은 isEmptyResult(정적 결과의 세 필드 모두 비어있을 때)에서만 헤드리스로 fallback. 실제 운영에서는 메타 태그로 name/image는 잡지만 가격은 동적 DOM 에 있어 못 가져오는 사이트가 다수이고, 그 결과 사용자에게 가격 없는 응답이 노출됨.

새 흐름:
  정적 시도 → isEmptyResult(static)
     ├─ true  → headless 전체 fallback (parser_type=headless_fallback, 기존)
     └─ false → needsPriceFallback(static)
                   ├─ true  → headless 호출, mergeResults 로 가격만 보강
                   │           (parser_type=static_with_price_fallback)
                   └─ false → static 그대로 반환 (parser_type=static)

변경:
- parsing-api/src/lib/parser/utils.js:
  - mergeResults(primary, secondary) 신규. primary 의 falsy 필드만 secondary 로 채움.
- parsing-api/src/controllers/itemController.js:
  - needsPriceFallback(data) 신규.
  - else if 분기 추가, parser_type 라벨 세분화.

성능 트레이드오프: 정적으로 가격 못 잡는 사이트가 다수 → 평균 응답시간 증가.
사용자 결정에 따른 의도된 변화 (가격 정확도 우선).

회귀 검증: mergeResults 4개 단위 케이스 통과 (deepStrictEqual).

closes #22

* Update api/src/main/java/com/wishboard/server/item/presentation/dto/request/CreateItemRequest.java



* [fix] deploy.sh 의 Playwright Chromium 설치를 node cli.js 직접 호출로 변경

aws s3 cp --recursive 는 node_modules/.bin/* 의 심볼릭 링크를 dereference 하고 execute bit 를 보존하지 않는다. 그 결과 운영에서 `npx playwright install` 호출 시:
  - chmod 안 됨 → Permission denied
  - chmod 후에도 .bin/playwright 가 cli.js 의 사본이 되어 require('./lib/program') 이 .bin/lib/program 을 찾아 MODULE_NOT_FOUND

해결: node 로 원본 cli.js 를 직접 호출. execute bit / 심볼릭 링크 둘 다 무관해진다.

  node node_modules/playwright/cli.js install chromium

ref PR #17 (인프라 디렉토리 분리)

---------