### PR TITLE
[hotfix] parsing-api PM2 exec_mode 를 cluster → fork 로 변경

### DIFF
--- a/v2-pm2-run-dev.js
+++ b/v2-pm2-run-dev.js
@@ -42,9 +42,6 @@ module.exports = {
             namespace: 'parsing-api-server',
             version: '2.0.0', // TODO 버전 변경 시 여기 수정
             instances: 1,
-            // Playwright 가 Chromium child process 를 spawn 할 때 stdio/IPC 가
-            // PM2 cluster IPC 와 충돌해 worker 가 ready 직후 종료되는 문제로
-            // fork mode 사용 (#26 / #27 참조). instances:1 이라 cluster 의 장점도 없음.
             exec_mode: 'fork',
             wait_ready: true, // 마스터 프로세스에게 ready 이벤트 대기
             listen_timeout: 50000,  // ms ... ready 이벤트를 기다릴 시간값

--- a/v2-pm2-run-dev.js
+++ b/v2-pm2-run-dev.js
@@ -3,7 +3,7 @@ module.exports = {
      * PM2 process definitions for Wishboard v2 (dev environment)
      *
      * ▸ wishboard-v2-api-server-dev         : Java Spring Boot (single instance, fork mode)
-     * ▸ wishboard-v2-parsing-api-server-dev : Node.js Parsing API (1 instance cluster)
+     * ▸ wishboard-v2-parsing-api-server-dev : Node.js Parsing API (1 instance fork)
      * ▸ wishboard-v2-push-scheduler-dev     : Node.js Push Scheduler (1 instance fork)
      *
      * 디렉토리 구조 (current/):
@@ -42,7 +42,10 @@ module.exports = {
             namespace: 'parsing-api-server',
             version: '2.0.0', // TODO 버전 변경 시 여기 수정
             instances: 1,
-            exec_mode: 'cluster',
+            // Playwright 가 Chromium child process 를 spawn 할 때 stdio/IPC 가
+            // PM2 cluster IPC 와 충돌해 worker 가 ready 직후 종료되는 문제로
+            // fork mode 사용 (#26 / #27 참조). instances:1 이라 cluster 의 장점도 없음.
+            exec_mode: 'fork',
             wait_ready: true, // 마스터 프로세스에게 ready 이벤트 대기
             listen_timeout: 50000,  // ms ... ready 이벤트를 기다릴 시간값
             kill_timeout: 5000,  // ms ... SIGINT 시그널을 보낸 후 프로세스가 종료되지 않았을 때 SIGKILL 시그널을 보내기까지의 대기 시간

--- a/v2-pm2-run-prod.js
+++ b/v2-pm2-run-prod.js
@@ -42,9 +42,6 @@ module.exports = {
             namespace: 'parsing-api-server',
             version: '2.0.0', // TODO 버전 변경 시 여기 수정
             instances: 1,
-            // Playwright 가 Chromium child process 를 spawn 할 때 stdio/IPC 가
-            // PM2 cluster IPC 와 충돌해 worker 가 ready 직후 종료되는 문제로
-            // fork mode 사용 (#26 / #27 참조). instances:1 이라 cluster 의 장점도 없음.
             exec_mode: 'fork',
             wait_ready: true, // 마스터 프로세스에게 ready 이벤트 대기
             listen_timeout: 50000,  // ms ... ready 이벤트를 기다릴 시간값

--- a/v2-pm2-run-prod.js
+++ b/v2-pm2-run-prod.js
@@ -3,7 +3,7 @@ module.exports = {
      * PM2 process definitions for Wishboard v2 (prod environment)
      *
      * ▸ wishboard-v2-api-server-prod         : Java Spring Boot (single instance, fork mode)
-     * ▸ wishboard-v2-parsing-api-server-prod : Node.js Parsing API (1 instance cluster)
+     * ▸ wishboard-v2-parsing-api-server-prod : Node.js Parsing API (1 instance fork)
      * ▸ wishboard-v2-push-scheduler-prod     : Node.js Push Scheduler (1 instance fork)
      *
      * 디렉토리 구조 (current/):
@@ -42,7 +42,10 @@ module.exports = {
             namespace: 'parsing-api-server',
             version: '2.0.0', // TODO 버전 변경 시 여기 수정
             instances: 1,
-            exec_mode: 'cluster',
+            // Playwright 가 Chromium child process 를 spawn 할 때 stdio/IPC 가
+            // PM2 cluster IPC 와 충돌해 worker 가 ready 직후 종료되는 문제로
+            // fork mode 사용 (#26 / #27 참조). instances:1 이라 cluster 의 장점도 없음.
+            exec_mode: 'fork',
             wait_ready: true, // 마스터 프로세스에게 ready 이벤트 대기
             listen_timeout: 50000,  // ms ... ready 이벤트를 기다릴 시간값
             kill_timeout: 5000,  // ms ... SIGINT 시그널을 보낸 후 프로세스가 종료되지 않았을 때 SIGKILL 시그널을 보내기까지의 대기 시간


### PR DESCRIPTION
## 증상

운영 prod 배포 후 **parsing-api 만** 기동 실패. push / api 서버는 정상.

`current/parsing-api/logs/2026-05-19.log` (winston):

```
22:23:33 [info] : [Parsing Api Server] on port 3001 | production
22:23:33 [info] : [browserPool] received SIGINT, closing Chromium
22:23:33 [info] : pm2 process closed
22:39:42 [info] : [Parsing Api Server] on port 3001 | production
22:39:42 [info] : [browserPool] received SIGINT, closing Chromium
22:39:43 [info] : pm2 process closed
```

새 인스턴스가 listen 직후 (`process.send('ready')` 호출 직후) **즉시** SIGINT 받고 죽음. 정상 cluster reload 흐름이 아님 — 정상이면 ready 후 **기존** 인스턴스가 죽어야 함.

## 원인

PM2 `exec_mode: 'cluster'` 는 master ↔ worker 간 IPC 채널을 사용. Playwright 가 Chromium child process 를 spawn 할 때 stdio/IPC 를 점유해 PM2 가 worker IPC 가 끊겼다고 오인 → worker 종료 트리거.

push 모듈은 `exec_mode: 'fork'` 라 같은 IPC 충돌이 없어서 정상 동작 (이번 PR 의 결정적 증거).

| 모듈 | exec_mode | Playwright 사용 | 동작 |
|---|---|---|---|
| api (Spring) | fork | — | ✓ |
| push | fork | — | ✓ |
| **parsing-api** | **cluster** | **YES** | **✗ (본 PR 수정 대상)** |

`instances: 1` 이라 cluster 의 본래 장점(다중 워커 로드밸런싱)도 없는 상태였습니다.

## 변경

`v2-pm2-run-prod.js` / `v2-pm2-run-dev.js` 의 parsing-api 항목:

```diff
-            exec_mode: 'cluster',
+            // Playwright 가 Chromium child process 를 spawn 할 때 stdio/IPC 가
+            // PM2 cluster IPC 와 충돌해 worker 가 ready 직후 종료되는 문제로
+            // fork mode 사용. instances:1 이라 cluster 의 장점도 없음.
+            exec_mode: 'fork',
             wait_ready: true,
```

다른 옵션 (`wait_ready`, `listen_timeout`, `kill_timeout`) 은 그대로 유지.

## Test plan

### 운영 검증
- [ ] **머지 후 dev 워크플로 자동 트리거** → dev 환경에서 parsing-api 정상 기동 확인
- [ ] `pm2 list` 에서 parsing-api status=online, restarts 가 증가하지 않음
- [ ] winston 로그에 `[Parsing Api Server] on port ... production` 후 SIGINT 가 **바로** 따라오지 않음
- [ ] 실제 `/parse?site=...` 요청 처리 정상

### 머지 후 운영 prod 적용 단계
1. main 머지 → prod 워크플로 자동 트리거
2. 운영 서버에서 deploy.sh 실행 (또는 워크플로가 처리)
3. 만약 이전 cluster 모드 PM2 메타데이터가 남아있으면 **`pm2 delete wishboard-v2-parsing-api-server-prod` 후 `pm2 start ecosystem.config.js --only wishboard-v2-parsing-api-server-prod` 강제 재시작** (cluster→fork 전환은 단순 reload 로 안 됨)

## 관련

- 운영 진단 로그: `~/wishboard-v2/prod/current/parsing-api/logs/2026-05-19.log`
- selector hint 부활 PR #26 과 독립 (이 PR 이 먼저 머지되어야 #26 의 효과를 운영에서 검증 가능)

🤖 Generated with [Claude Code](https://claude.com/claude-code)